### PR TITLE
!feat: text button

### DIFF
--- a/src/Components/Button/Button.stories.tsx
+++ b/src/Components/Button/Button.stories.tsx
@@ -6,59 +6,87 @@ const meta = {
   title: "Core/Button",
   component: Button,
   tags: ["autodocs"],
-  argTypes: {}
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["filled", "outlined", "text"],
+      description: "The visual style variant of the button",
+      defaultValue: "filled",
+      table: {
+        defaultValue: { summary: "filled" }
+      }
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the button is disabled",
+      defaultValue: false
+    },
+    isLoading: {
+      control: "boolean",
+      description: "Whether to show a loading spinner",
+      defaultValue: false
+    },
+    icon: {
+      description: "Icon configuration object",
+      control: "object"
+    },
+    className: {
+      description: "Additional CSS classes to apply",
+      control: "text"
+    },
+    onClick: {
+      description: "Click handler function",
+      action: "clicked"
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A versatile button component supporting different variants, states, and icon configurations."
+      }
+    }
+  }
 } satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Filled Variant
 export const Filled: Story = {
   args: {
-    children: "Button"
+    children: "Button",
+    variant: "filled"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Default filled variant with primary color"
+      }
+    }
   }
 };
 
 export const FilledDisabled: Story = {
   args: {
     children: "Button",
+    variant: "filled",
     disabled: true
   }
 };
 
-export const FilledSpining: Story = {
+export const FilledLoading: Story = {
   args: {
     children: "Button",
+    variant: "filled",
     isLoading: true
   }
 };
 
-export const Outlined: Story = {
+export const FilledWithLeftIcon: Story = {
   args: {
     children: "Button",
-    outlined: true
-  }
-};
-
-export const OutlinedDisabled: Story = {
-  args: {
-    children: "Button",
-    outlined: true,
-    disabled: true
-  }
-};
-
-export const OutlinedSpinning: Story = {
-  args: {
-    children: "Button",
-    outlined: true,
-    isLoading: true
-  }
-};
-
-export const WithLeftIcon: Story = {
-  args: {
-    children: "Button",
-    outlined: true,
+    variant: "filled",
     icon: {
       iconName: "IconBomb",
       iconPosition: "left"
@@ -66,9 +94,10 @@ export const WithLeftIcon: Story = {
   }
 };
 
-export const WithRightIcon: Story = {
+export const FilledWithRightIcon: Story = {
   args: {
     children: "Button",
+    variant: "filled",
     icon: {
       iconName: "IconBomb",
       iconPosition: "right"
@@ -76,7 +105,114 @@ export const WithRightIcon: Story = {
   }
 };
 
-export const WithIconClassName: Story = {
+// Outlined Variant
+export const Outlined: Story = {
+  args: {
+    children: "Button",
+    variant: "outlined"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Outlined variant with transparent background"
+      }
+    }
+  }
+};
+
+export const OutlinedDisabled: Story = {
+  args: {
+    children: "Button",
+    variant: "outlined",
+    disabled: true
+  }
+};
+
+export const OutlinedLoading: Story = {
+  args: {
+    children: "Button",
+    variant: "outlined",
+    isLoading: true
+  }
+};
+
+export const OutlinedWithLeftIcon: Story = {
+  args: {
+    children: "Button",
+    variant: "outlined",
+    icon: {
+      iconName: "IconBomb",
+      iconPosition: "left"
+    }
+  }
+};
+
+export const OutlinedWithRightIcon: Story = {
+  args: {
+    children: "Button",
+    variant: "outlined",
+    icon: {
+      iconName: "IconBomb",
+      iconPosition: "right"
+    }
+  }
+};
+
+// Text Variant
+export const Text: Story = {
+  args: {
+    children: "Button",
+    variant: "text"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Text variant with no background or border"
+      }
+    }
+  }
+};
+
+export const TextDisabled: Story = {
+  args: {
+    children: "Button",
+    variant: "text",
+    disabled: true
+  }
+};
+
+export const TextLoading: Story = {
+  args: {
+    children: "Button",
+    variant: "text",
+    isLoading: true
+  }
+};
+
+export const TextWithLeftIcon: Story = {
+  args: {
+    children: "Button",
+    variant: "text",
+    icon: {
+      iconName: "IconBomb",
+      iconPosition: "left"
+    }
+  }
+};
+
+export const TextWithRightIcon: Story = {
+  args: {
+    children: "Button",
+    variant: "text",
+    icon: {
+      iconName: "IconBomb",
+      iconPosition: "right"
+    }
+  }
+};
+
+// Special Variants
+export const WithCustomIcon: Story = {
   args: {
     children: "Button",
     icon: {
@@ -90,9 +226,7 @@ export const WithIconClassName: Story = {
 export const LoadingWithIcon: Story = {
   args: {
     children: "Button",
-    outlined: true,
     isLoading: true,
-    className: "button--green",
     icon: {
       iconName: "IconBomb",
       iconPosition: "left"
@@ -100,29 +234,45 @@ export const LoadingWithIcon: Story = {
   }
 };
 
+// Color Variations
 export const Red: Story = {
   args: {
-    children: "Button",
-    outlined: true,
-    isLoading: true,
+    children: "Red Button",
     className: "button--red"
-  }
-};
-
-export const Gray: Story = {
-  args: {
-    children: "Button",
-    outlined: true,
-    isLoading: true,
-    className: "button--gray"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A red themed button using the button--red class"
+      }
+    }
   }
 };
 
 export const Green: Story = {
   args: {
-    children: "Button",
-    outlined: true,
-    isLoading: true,
+    children: "Green Button",
     className: "button--green"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A green themed button using the button--green class"
+      }
+    }
+  }
+};
+
+export const Gray: Story = {
+  args: {
+    children: "Gray Button",
+    className: "button--gray"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A gray themed button using the button--gray class"
+      }
+    }
   }
 };

--- a/src/Components/Button/Button.test.tsx
+++ b/src/Components/Button/Button.test.tsx
@@ -25,12 +25,20 @@ describe("Button component", () => {
     expect(screen.getByTestId("icon-spinner")).toBeInTheDocument();
   });
 
-  test("has outlined styles when outlined prop is true", () => {
-    render(<Button outlined>Click me</Button>);
+  test("has outlined styles when variant is outlined", () => {
+    render(<Button variant='outlined'>Click me</Button>);
     const button = screen.getByRole("button");
     expect(button).toHaveClass("yl-border-2");
     expect(button).toHaveClass("yl-text-primary");
     expect(button).toHaveClass("yl-border-primary");
+  });
+
+  test("has text styles when variant is text", () => {
+    render(<Button variant='text'>Click me</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("yl-border-transparent");
+    expect(button).toHaveClass("yl-text-primary");
+    expect(button).toHaveClass("hover:yl-bg-primary/10");
   });
 
   test("handles click events", () => {
@@ -63,11 +71,42 @@ describe("Button component", () => {
 
   test("has correct styles when disabled and outlined", () => {
     render(
-      <Button disabled outlined>
+      <Button disabled variant='outlined'>
         Button
       </Button>
     );
     const button = screen.getByRole("button");
+    expect(button).toHaveClass("yl-text-primary");
+  });
+
+  test("has correct styles when disabled and text variant", () => {
+    render(
+      <Button disabled variant='text'>
+        Button
+      </Button>
+    );
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("yl-text-primary");
+    expect(button).toHaveClass("yl-border-transparent");
+    expect(button).toHaveClass("yl-opacity-70");
+  });
+
+  test("has correct styles when loading and text variant", () => {
+    render(
+      <Button isLoading variant='text'>
+        Button
+      </Button>
+    );
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("yl-border-transparent");
+    expect(screen.getByTestId("icon-spinner")).toBeInTheDocument();
+  });
+
+  test("has correct hover styles for text variant", () => {
+    render(<Button variant='text'>Button</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("hover:yl-bg-primary/10");
+    expect(button).toHaveClass("yl-border-transparent");
     expect(button).toHaveClass("yl-text-primary");
   });
 });

--- a/src/Components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/Components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component > renders correctly - snapshot test 1`] = `
 <DocumentFragment>
   <button
-    class="yl-select-none yl-border-2 yl-border-primary yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-primary hover:yl-bg-transparent hover:yl-text-primary hover:yl-fill-primary yl-text-primary-background-color"
+    class="yl-select-none yl-border-2 yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-primary yl-border-primary hover:yl-bg-transparent hover:yl-text-primary hover:yl-fill-primary yl-text-primary-background-color "
     type="button"
   >
     <div

--- a/src/Components/Button/index.tsx
+++ b/src/Components/Button/index.tsx
@@ -15,33 +15,39 @@ const Button: React.FC<IButtonProps> = (
     type = "button",
     icon,
     isLoading = false,
-    outlined = false
+    variant = "filled"
   } = {
     onClick: () => null,
     children: null,
     className: "",
     disabled: false,
-    outlined: false,
+    variant: "filled",
     isLoading: false
   }
 ) => {
   let cls =
-    "yl-select-none yl-border-2 yl-border-primary yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md ";
+    "yl-select-none yl-border-2 yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md ";
 
   if (disabled) {
     cls += "yl-cursor-not-allowed yl-opacity-70 ";
-    if (outlined) {
-      cls += "yl-text-primary ";
+    if (variant === "outlined") {
+      cls += "yl-text-primary yl-border-primary ";
+    } else if (variant === "text") {
+      cls += "yl-text-primary yl-border-transparent ";
     } else {
-      cls += "yl-text-primary-background-color yl-bg-primary ";
+      cls +=
+        "yl-text-primary-background-color yl-bg-primary yl-border-primary ";
     }
   } else {
-    if (outlined) {
+    if (variant === "outlined") {
       cls +=
-        "yl-bg-transparent yl-text-primary yl-fill-primary hover:yl-bg-primary hover:yl-fill-primary-background-color hover:yl-text-primary-background-color";
+        "yl-bg-transparent yl-text-primary yl-fill-primary yl-border-primary hover:yl-bg-primary hover:yl-fill-primary-background-color hover:yl-text-primary-background-color ";
+    } else if (variant === "text") {
+      cls +=
+        "yl-bg-transparent yl-text-primary yl-fill-primary yl-border-transparent hover:yl-bg-primary/10 ";
     } else {
       cls +=
-        "yl-bg-primary hover:yl-bg-transparent hover:yl-text-primary hover:yl-fill-primary yl-text-primary-background-color";
+        "yl-bg-primary yl-border-primary hover:yl-bg-transparent hover:yl-text-primary hover:yl-fill-primary yl-text-primary-background-color ";
     }
   }
 

--- a/src/Components/Button/types.ts
+++ b/src/Components/Button/types.ts
@@ -9,7 +9,7 @@ export interface IButtonProps {
   disabled?: boolean;
   type?: "button" | "submit" | "reset";
   isLoading?: boolean;
-  outlined?: boolean;
+  variant?: "filled" | "outlined" | "text";
   icon?: {
     iconName?: IconName;
     iconClassName?: string;

--- a/src/Components/ThemeBuilder/__snapshots__/ThemeBuilder.test.tsx.snap
+++ b/src/Components/ThemeBuilder/__snapshots__/ThemeBuilder.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ThemeBuilder component > renders correctly with given props 1`] = `
         class="yl-flex yl-gap-1 yl-flex-col md:yl-flex-row"
       >
         <button
-          class="yl-select-none yl-border-2 yl-border-primary yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-transparent yl-text-primary yl-fill-primary hover:yl-bg-primary hover:yl-fill-primary-background-color hover:yl-text-primary-background-color primary-button yl-h-12 yl-min-w-[120px] yl-shadow-none"
+          class="yl-select-none yl-border-2 yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-primary yl-border-primary hover:yl-bg-transparent hover:yl-text-primary hover:yl-fill-primary yl-text-primary-background-color  primary-button yl-h-12 yl-min-w-[120px] yl-shadow-none"
           type="button"
         >
           <div
@@ -27,7 +27,7 @@ exports[`ThemeBuilder component > renders correctly with given props 1`] = `
           </div>
         </button>
         <button
-          class="yl-select-none yl-border-2 yl-border-primary yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-transparent yl-text-primary yl-fill-primary hover:yl-bg-primary hover:yl-fill-primary-background-color hover:yl-text-primary-background-color yl-h-12 yl-min-w-[120px] yl-shadow-none"
+          class="yl-select-none yl-border-2 yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-primary yl-border-primary hover:yl-bg-transparent hover:yl-text-primary hover:yl-fill-primary yl-text-primary-background-color  yl-h-12 yl-min-w-[120px] yl-shadow-none"
           type="button"
         >
           <div
@@ -44,7 +44,7 @@ exports[`ThemeBuilder component > renders correctly with given props 1`] = `
           </div>
         </button>
         <button
-          class="yl-select-none yl-border-2 yl-border-primary yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-transparent yl-text-primary yl-fill-primary hover:yl-bg-primary hover:yl-fill-primary-background-color hover:yl-text-primary-background-color yl-h-12 yl-min-w-[120px] yl-shadow-none"
+          class="yl-select-none yl-border-2 yl-px-3 yl-py-2 yl-font-semibold yl-tracking-tight yl-rounded-md yl-bg-primary yl-border-primary hover:yl-bg-transparent hover:yl-text-primary hover:yl-fill-primary yl-text-primary-background-color  yl-h-12 yl-min-w-[120px] yl-shadow-none"
           type="button"
         >
           <div


### PR DESCRIPTION
## This is a breaking change.

The outlined prop has been renamed to variant with 3 possible values: "filled" (default), "outlined", "text". Users of this library would need to at least change every outlined button to `<Button variant="outlined">Click me</Button>`

## Description
This PR introduces a new Text Button variant.
**Why?** Text buttons are handy to have less visual prominence, so it should/can be used for low emphasis actions, such as an alternative option.

![image](https://github.com/user-attachments/assets/e97adb7e-73d7-4a7c-9d2f-9c6dcfc8cb40)
